### PR TITLE
fix: api nginx 의존성 depends_on 필드 제거

### DIFF
--- a/docker-compose-prod.yaml
+++ b/docker-compose-prod.yaml
@@ -61,7 +61,6 @@ services:
       - appdata:/data/app_logs
     depends_on:
       - mysql
-      - nginx
 
 volumes:
   mydata:


### PR DESCRIPTION
1. docker-compose api nginx 의존성 제거