### PR TITLE
feat: #132 상세 게시글 압축 파일 다운로드 기능 구현

### DIFF
--- a/app/shop/src/main/java/com/shoppingmall/api/FileRestController.java
+++ b/app/shop/src/main/java/com/shoppingmall/api/FileRestController.java
@@ -13,6 +13,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -68,9 +69,8 @@ public class FileRestController {
         );
     }
 
-    @GetMapping(value = "/download/compress/{postId}", produces = "application/zip")
+    @GetMapping(value = "/download/compress/{domain}/{postId}", produces = "application/zip")
     public void downloadMultiZipFile(@PathVariable("postId") Long postId, HttpServletResponse response) throws IOException {
-        // post(1) : files(N) + postId(required : true)
         List<File> files = fileService.getFilesByPostId(postId)
                 .stream()
                 .map(fileResponseDto -> new File(fileResponseDto.getFilePath()))


### PR DESCRIPTION
1. 상세 게시글에서 첨부된 파일이 있는 경우, 파일 압축 다운로드 클릭하면 gzip 형태 모든 파일 다운로드